### PR TITLE
다른 유저 프로필 정보 조회 구현

### DIFF
--- a/src/main/java/com/command/itdaserver/domain/profile/presentation/ProfileController.java
+++ b/src/main/java/com/command/itdaserver/domain/profile/presentation/ProfileController.java
@@ -1,0 +1,21 @@
+package com.command.itdaserver.domain.profile.presentation;
+
+import com.command.itdaserver.domain.profile.service.QueryUserProfileService;
+import com.command.itdaserver.domain.user.presentation.dto.response.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/profile")
+@RequiredArgsConstructor
+public class ProfileController {
+    private final QueryUserProfileService queryUserProfileService;
+
+    @GetMapping("/{userId}")
+    public UserResponse queryUserProfile(@PathVariable String userId) {
+        return queryUserProfileService.execute(userId);
+    }
+}

--- a/src/main/java/com/command/itdaserver/domain/profile/service/QueryUserProfileService.java
+++ b/src/main/java/com/command/itdaserver/domain/profile/service/QueryUserProfileService.java
@@ -1,4 +1,4 @@
-package com.command.itdaserver.domain.user.service;
+package com.command.itdaserver.domain.profile.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class QueryUserProfileService {
+
 }

--- a/src/main/java/com/command/itdaserver/domain/profile/service/QueryUserProfileService.java
+++ b/src/main/java/com/command/itdaserver/domain/profile/service/QueryUserProfileService.java
@@ -1,10 +1,21 @@
 package com.command.itdaserver.domain.profile.service;
 
+import com.command.itdaserver.domain.user.domain.User;
+import com.command.itdaserver.domain.user.domain.repository.UserRepository;
+import com.command.itdaserver.domain.user.exception.UserNotFoundException;
+import com.command.itdaserver.domain.user.presentation.dto.response.UserResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class QueryUserProfileService {
+    private final UserRepository userRepository;
 
+    public UserResponse execute(String userId) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> UserNotFoundException.EXCEPTION);
+
+        return UserResponse.from(user);
+    }
 }

--- a/src/main/java/com/command/itdaserver/domain/user/domain/User.java
+++ b/src/main/java/com/command/itdaserver/domain/user/domain/User.java
@@ -25,7 +25,7 @@ public class User extends BaseIdEntity {
     @Column(nullable = false)
     private AuthProvider provider;
 
-    private String userImage;
+    private String userImage; // 추후 s3 도입 후 리펙터링 예정
 
     @Column(nullable = false)
     private String name;

--- a/src/main/java/com/command/itdaserver/domain/user/domain/User.java
+++ b/src/main/java/com/command/itdaserver/domain/user/domain/User.java
@@ -25,6 +25,8 @@ public class User extends BaseIdEntity {
     @Column(nullable = false)
     private AuthProvider provider;
 
+    private String userImage;
+
     @Column(nullable = false)
     private String name;
 

--- a/src/main/java/com/command/itdaserver/domain/user/presentation/dto/response/UserResponse.java
+++ b/src/main/java/com/command/itdaserver/domain/user/presentation/dto/response/UserResponse.java
@@ -6,7 +6,7 @@ import com.command.itdaserver.domain.user.domain.enums.Major;
 import com.command.itdaserver.domain.user.domain.enums.School;
 
 public record UserResponse(
-        String serImage,
+        String userImage, // 추후 s3 도입 후 리펙터링 예정
         String name,
         String userId,
         String email,
@@ -18,7 +18,7 @@ public record UserResponse(
 
     public static UserResponse from(User user) {
         return new UserResponse(
-                user.getUserImage(),
+                user.getUserImage(), // 추후 s3 도입 후 리펙터링 예정
                 user.getName(),
                 user.getUserId(),
                 user.getEmail(),

--- a/src/main/java/com/command/itdaserver/domain/user/presentation/dto/response/UserResponse.java
+++ b/src/main/java/com/command/itdaserver/domain/user/presentation/dto/response/UserResponse.java
@@ -18,6 +18,7 @@ public record UserResponse(
 
     public static UserResponse from(User user) {
         return new UserResponse(
+                user.getUserImage(),
                 user.getName(),
                 user.getUserId(),
                 user.getEmail(),

--- a/src/main/java/com/command/itdaserver/domain/user/presentation/dto/response/UserResponse.java
+++ b/src/main/java/com/command/itdaserver/domain/user/presentation/dto/response/UserResponse.java
@@ -6,6 +6,7 @@ import com.command.itdaserver.domain.user.domain.enums.Major;
 import com.command.itdaserver.domain.user.domain.enums.School;
 
 public record UserResponse(
+        String serImage,
         String name,
         String userId,
         String email,

--- a/src/main/java/com/command/itdaserver/domain/user/service/QueryUserProfileService.java
+++ b/src/main/java/com/command/itdaserver/domain/user/service/QueryUserProfileService.java
@@ -1,0 +1,9 @@
+package com.command.itdaserver.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QueryUserProfileService {
+}


### PR DESCRIPTION
## 💡 배경 및 개요

> 다른 유저 프로필 조회 구현

Resolves: #

## 📃 작업내용

> 다른 유저 프로필을 UserId로 조회가 가능한 메서드 구현 및 컨트롤러 매핑

## 🔀 변경사항

> 다른 유저 프로필 조회 기능 구현

## 🙋‍♂️ 리뷰노트

> 현재 User Entity와 UserResponse에서 UserImage가 있는데 제가 s3를 할 줄 모르는 관개로 개발을 하지 못했습니다. 주석으로 추후 수정여부 달아놓았으니 그 부분 확인해서 개발 진행해주시면 될거 같습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
