### PR TITLE
Refactor/disclosure fields

### DIFF
--- a/src/main/java/com/command/itdaserver/domain/profile/presentation/dto/request/UserPublicProfileRequest.java
+++ b/src/main/java/com/command/itdaserver/domain/profile/presentation/dto/request/UserPublicProfileRequest.java
@@ -10,16 +10,8 @@ public record UserPublicProfileRequest(
         @JsonProperty("email_view")
         boolean isEmailPublic,
 
-        @JsonProperty("major_view")
-        boolean isMajorPublic,
-
-        @JsonProperty("custom_major_view")
-        boolean isCustomMajorPublic,
-
         @JsonProperty("grade_view")
-        boolean isGradePublic,
+        boolean isGradePublic
 
-        @JsonProperty("school_view")
-        boolean isSchoolPublic
 ) {
 }

--- a/src/main/java/com/command/itdaserver/domain/profile/presentation/dto/response/UserProfileDisclosureResponse.java
+++ b/src/main/java/com/command/itdaserver/domain/profile/presentation/dto/response/UserProfileDisclosureResponse.java
@@ -5,19 +5,13 @@ import com.command.itdaserver.domain.user.domain.UserDisclosure;
 public record UserProfileDisclosureResponse(
         boolean isNamePublic,
         boolean isEmailPublic,
-        boolean isMajorPublic,
-        boolean isCustomMajorPublic,
-        boolean isGradePublic,
-        boolean isSchoolPublic
+        boolean isGradePublic
 ) {
     public static UserProfileDisclosureResponse of(UserDisclosure userDisclosure) {
         return new UserProfileDisclosureResponse(
                 userDisclosure.isNamePublic(),
                 userDisclosure.isEmailPublic(),
-                userDisclosure.isMajorPublic(),
-                userDisclosure.isCustomMajorPublic(),
-                userDisclosure.isGradePublic(),
-                userDisclosure.isSchoolPublic()
+                userDisclosure.isGradePublic()
         );
     }
 }

--- a/src/main/java/com/command/itdaserver/domain/profile/presentation/dto/response/UserPublicProfileResponse.java
+++ b/src/main/java/com/command/itdaserver/domain/profile/presentation/dto/response/UserPublicProfileResponse.java
@@ -23,10 +23,10 @@ public record UserPublicProfileResponse(
                 user.getUserId(),
                 disclosure.isNamePublic() ? user.getName() : null,
                 disclosure.isEmailPublic() ? user.getEmail() : null,
-                disclosure.isMajorPublic() ? user.getMajor() : null,
-                disclosure.isCustomMajorPublic() ? user.getCustomMajor() : null,
+                user.getMajor(),
+                user.getCustomMajor(),
                 disclosure.isGradePublic() ? user.getGrade() : null,
-                disclosure.isSchoolPublic() ? user.getSchool() : null
+                user.getSchool()
         );
     }
 }

--- a/src/main/java/com/command/itdaserver/domain/user/domain/UserDisclosure.java
+++ b/src/main/java/com/command/itdaserver/domain/user/domain/UserDisclosure.java
@@ -24,23 +24,11 @@ public class UserDisclosure extends BaseIdEntity {
     private boolean isEmailPublic;
 
     @Column(nullable = false)
-    private boolean isMajorPublic;
-
-    @Column(nullable = false)
-    private boolean isCustomMajorPublic;
-
-    @Column(nullable = false)
-    private boolean isSchoolPublic;
-
-    @Column(nullable = false)
     private boolean isGradePublic;
 
     public void update(UserPublicProfileRequest request) {
         this.isNamePublic = request.isNamePublic();
         this.isEmailPublic = request.isEmailPublic();
-        this.isMajorPublic = request.isMajorPublic();
-        this.isCustomMajorPublic = request.isCustomMajorPublic();
-        this.isSchoolPublic = request.isSchoolPublic();
         this.isGradePublic = request.isGradePublic();
     }
 
@@ -49,9 +37,6 @@ public class UserDisclosure extends BaseIdEntity {
                 .user(user)
                 .isNamePublic(true)
                 .isEmailPublic(true)
-                .isMajorPublic(true)
-                .isCustomMajorPublic(true)
-                .isSchoolPublic(true)
                 .isGradePublic(true)
                 .build();
     }


### PR DESCRIPTION
## 💡 배경 및 개요


- 프로필 공개 설정에서 학교와 전공 필드는 사용자가 비공개로 설정할 수 없고 항상 공개되어야 하는 요구사항이 있어 수정했습니다. 


Resolves: 
## 📃 작업내용
 - UserDisclosure 엔티티에서 school/major 관련 필드 제거                                                                                                                       
  - 공개설정 Request/Response DTO에서 school/major 필드 제거                                                                                                                    
  - 프로필 조회 시 school/major 항상 공개 처리  
> PR에서 한 작업을 작성해주세요!

## 🔀 변경사항
 - ```UserDisclosure```엔티티의 ```isSchoolPublic```, ```isMajorPublic```, ```isCustomMajorPublic``` 필드 및 관련 로직 제거
- ```UserPublicProfileRequest```와```UserProfileDisclosureResponse```의 school/major 공개 여부 필드 제거  
- UserPublicProfileResponse의 school/major를 disclosure 체크 없이 항상 반환하도록 수정


## 🙋‍♂️ 리뷰노트
- 기존에 DB에 저장된 isSchoolPublic, isMajorPublic, isCustomMajorPublic 컬럼은 더 이상 사용하지 않습니다
- 기존 DB에 사용중이라면 마이그레이션을 진행해 주세요
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
