### PR TITLE
Refactor/questions to form entity

### DIFF
--- a/src/main/java/com/command/itdaserver/domain/post/domain/ApplyForm.java
+++ b/src/main/java/com/command/itdaserver/domain/post/domain/ApplyForm.java
@@ -44,5 +44,6 @@ public class ApplyForm extends BaseIdEntity {
 
     public void addQuestion(Question question) {
         questions.add(question);
+        question.assignApplyForm(this);
     }
 }

--- a/src/main/java/com/command/itdaserver/domain/post/domain/ApplyForm.java
+++ b/src/main/java/com/command/itdaserver/domain/post/domain/ApplyForm.java
@@ -1,0 +1,48 @@
+package com.command.itdaserver.domain.post.domain;
+
+import com.command.itdaserver.global.entity.BaseIdEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApplyForm extends BaseIdEntity {
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false, unique = true)
+    private Post post;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @NotBlank
+    @Column(nullable = false)
+    private String description;
+
+    @OneToMany(mappedBy = "applyForm", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("questionNumber ASC")
+    @BatchSize(size = 10)
+    private List<Question> questions = new ArrayList<>();
+
+    public static ApplyForm create(Post post, String title, String description) {
+        ApplyForm applyForm = new ApplyForm();
+        applyForm.post = post;
+        applyForm.title = title;
+        applyForm.description = description;
+        return applyForm;
+    }
+
+    public void addQuestion(Question question) {
+        questions.add(question);
+    }
+}

--- a/src/main/java/com/command/itdaserver/domain/post/domain/Post.java
+++ b/src/main/java/com/command/itdaserver/domain/post/domain/Post.java
@@ -52,11 +52,6 @@ public class Post extends BaseIdEntity {
     @BatchSize(size = 10)
     private List<Major> majors = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    @OrderBy("questionNumber ASC")
-    @BatchSize(size = 10)
-    private List<Question> questions = new ArrayList<>();
-
     @OneToOne(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private ApplyForm applyForm;
 
@@ -109,11 +104,6 @@ public class Post extends BaseIdEntity {
 
     public boolean hasApplyForm() {
         return applyForm != null;
-    }
-
-    public void addQuestion(Question question) {
-        questions.add(question);
-        question.assignPost(this);
     }
 
     public void toggleLike(User user) {

--- a/src/main/java/com/command/itdaserver/domain/post/domain/Post.java
+++ b/src/main/java/com/command/itdaserver/domain/post/domain/Post.java
@@ -57,6 +57,9 @@ public class Post extends BaseIdEntity {
     @BatchSize(size = 10)
     private List<Question> questions = new ArrayList<>();
 
+    @OneToOne(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private ApplyForm applyForm;
+
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "post_likes",
             joinColumns = @JoinColumn(name = "post_id"),
@@ -102,6 +105,10 @@ public class Post extends BaseIdEntity {
 
     public boolean isClosed() {
         return applyDeadline.isBefore(LocalDateTime.now());
+    }
+
+    public boolean hasApplyForm() {
+        return applyForm != null;
     }
 
     public void addQuestion(Question question) {

--- a/src/main/java/com/command/itdaserver/domain/post/domain/Question.java
+++ b/src/main/java/com/command/itdaserver/domain/post/domain/Question.java
@@ -24,6 +24,11 @@ public class Question extends BaseIdEntity {
     @JsonIgnore
     private Post post;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "apply_form_id")
+    @JsonIgnore
+    private ApplyForm applyForm;
+
     @NotNull
     private Integer questionNumber;
 
@@ -55,6 +60,10 @@ public class Question extends BaseIdEntity {
 
     void assignPost(Post post) {
         this.post = post;
+    }
+
+    void assignApplyForm(ApplyForm applyForm) {
+        this.applyForm = applyForm;
     }
 
     public void addOptions(QuestionOption option) {

--- a/src/main/java/com/command/itdaserver/domain/post/domain/Question.java
+++ b/src/main/java/com/command/itdaserver/domain/post/domain/Question.java
@@ -20,11 +20,6 @@ import java.util.List;
 public class Question extends BaseIdEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
-    @JsonIgnore
-    private Post post;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "apply_form_id")
     @JsonIgnore
     private ApplyForm applyForm;
@@ -56,10 +51,6 @@ public class Question extends BaseIdEntity {
         this.answerType = answerType;
         this.multiple = multiple;
         this.required = required;
-    }
-
-    void assignPost(Post post) {
-        this.post = post;
     }
 
     void assignApplyForm(ApplyForm applyForm) {

--- a/src/main/java/com/command/itdaserver/domain/post/domain/repository/ApplyFormRepository.java
+++ b/src/main/java/com/command/itdaserver/domain/post/domain/repository/ApplyFormRepository.java
@@ -1,0 +1,12 @@
+package com.command.itdaserver.domain.post.domain.repository;
+
+import com.command.itdaserver.domain.post.domain.ApplyForm;
+import com.command.itdaserver.domain.post.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ApplyFormRepository extends JpaRepository<ApplyForm, Long> {
+    Optional<ApplyForm> findByPost(Post post);
+    boolean existsByPost(Post post);
+}

--- a/src/main/java/com/command/itdaserver/domain/post/domain/repository/QuestionRepository.java
+++ b/src/main/java/com/command/itdaserver/domain/post/domain/repository/QuestionRepository.java
@@ -1,5 +1,6 @@
 package com.command.itdaserver.domain.post.domain.repository;
 
+import com.command.itdaserver.domain.post.domain.ApplyForm;
 import com.command.itdaserver.domain.post.domain.Post;
 import com.command.itdaserver.domain.post.domain.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,5 @@ import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     Optional<Question> findByIdAndPost(Long id, Post post);
+    Optional<Question> findByIdAndApplyForm(Long id, ApplyForm applyForm);
 }

--- a/src/main/java/com/command/itdaserver/domain/post/domain/repository/QuestionRepository.java
+++ b/src/main/java/com/command/itdaserver/domain/post/domain/repository/QuestionRepository.java
@@ -1,13 +1,11 @@
 package com.command.itdaserver.domain.post.domain.repository;
 
 import com.command.itdaserver.domain.post.domain.ApplyForm;
-import com.command.itdaserver.domain.post.domain.Post;
 import com.command.itdaserver.domain.post.domain.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
-    Optional<Question> findByIdAndPost(Long id, Post post);
     Optional<Question> findByIdAndApplyForm(Long id, ApplyForm applyForm);
 }

--- a/src/main/java/com/command/itdaserver/domain/post/exceptions/ApplyFormNotFoundException.java
+++ b/src/main/java/com/command/itdaserver/domain/post/exceptions/ApplyFormNotFoundException.java
@@ -1,0 +1,11 @@
+package com.command.itdaserver.domain.post.exceptions;
+
+import com.command.itdaserver.global.error.exception.ErrorCode;
+import com.command.itdaserver.global.error.exception.ItdaException;
+
+public class ApplyFormNotFoundException extends ItdaException {
+    public static final ItdaException EXCEPTION = new ApplyFormNotFoundException();
+    public ApplyFormNotFoundException() {
+        super(ErrorCode.APPLY_FORM_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/command/itdaserver/domain/post/presentation/PostController.java
+++ b/src/main/java/com/command/itdaserver/domain/post/presentation/PostController.java
@@ -8,7 +8,6 @@ import com.command.itdaserver.domain.post.presentation.dto.response.AnswerRespon
 import com.command.itdaserver.domain.post.presentation.dto.response.ApplyFormResponse;
 import com.command.itdaserver.domain.post.presentation.dto.response.PostResponse;
 import com.command.itdaserver.domain.post.presentation.dto.response.PostSummaryResponse;
-import com.command.itdaserver.domain.post.presentation.dto.response.QuestionResponse;
 import com.command.itdaserver.domain.post.service.CreateApplyFormService;
 import com.command.itdaserver.domain.post.service.CreatePostService;
 import com.command.itdaserver.domain.post.service.GetApplyFormService;
@@ -67,9 +66,9 @@ public class PostController {
     }
 
     @PostMapping("/{postId}/apply-form")
-    public List<QuestionResponse> createApplyForm(@PathVariable Long postId,
-                                                  @AuthenticationPrincipal CustomUserDetails userDetails,
-                                                  @Valid @RequestBody CreateFormRequest request) {
+    public ApplyFormResponse createApplyForm(@PathVariable Long postId,
+                                             @AuthenticationPrincipal CustomUserDetails userDetails,
+                                             @Valid @RequestBody CreateFormRequest request) {
         return createApplyFormService.execute(postId, request, userDetails);
     }
 

--- a/src/main/java/com/command/itdaserver/domain/post/presentation/PostController.java
+++ b/src/main/java/com/command/itdaserver/domain/post/presentation/PostController.java
@@ -5,11 +5,13 @@ import com.command.itdaserver.domain.post.presentation.dto.request.CreatePostReq
 import com.command.itdaserver.domain.post.presentation.dto.request.SubmitAnswerRequest;
 import com.command.itdaserver.domain.post.presentation.dto.request.UpdatePostRequest;
 import com.command.itdaserver.domain.post.presentation.dto.response.AnswerResponse;
+import com.command.itdaserver.domain.post.presentation.dto.response.ApplyFormResponse;
 import com.command.itdaserver.domain.post.presentation.dto.response.PostResponse;
 import com.command.itdaserver.domain.post.presentation.dto.response.PostSummaryResponse;
 import com.command.itdaserver.domain.post.presentation.dto.response.QuestionResponse;
 import com.command.itdaserver.domain.post.service.CreateApplyFormService;
 import com.command.itdaserver.domain.post.service.CreatePostService;
+import com.command.itdaserver.domain.post.service.GetApplyFormService;
 import com.command.itdaserver.domain.post.service.GetPostService;
 import com.command.itdaserver.domain.post.service.SubmitAnswerService;
 import com.command.itdaserver.domain.post.service.GetPostsService;
@@ -34,6 +36,7 @@ public class PostController {
     private final GetPostsService getPostsService;
     private final CreatePostService createPostService;
     private final CreateApplyFormService createApplyFormService;
+    private final GetApplyFormService getApplyFormService;
     private final SubmitAnswerService submitAnswerService;
     private final ToggleLikeService toggleLikeService;
     private final ToggleBookmarkService toggleBookmarkService;
@@ -56,6 +59,11 @@ public class PostController {
     public PostResponse createPost(@AuthenticationPrincipal CustomUserDetails customUserDetails,
                                    @Valid @RequestBody CreatePostRequest request) {
         return createPostService.execute(request, customUserDetails);
+    }
+
+    @GetMapping("/{postId}/apply-form")
+    public ApplyFormResponse getApplyForm(@PathVariable Long postId) {
+        return getApplyFormService.execute(postId);
     }
 
     @PostMapping("/{postId}/apply-form")

--- a/src/main/java/com/command/itdaserver/domain/post/presentation/dto/request/CreateFormRequest.java
+++ b/src/main/java/com/command/itdaserver/domain/post/presentation/dto/request/CreateFormRequest.java
@@ -12,6 +12,12 @@ import java.util.List;
 
 @Data
 public class CreateFormRequest {
+    @NotBlank(message = "신청서 제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "신청서 설명은 필수입니다.")
+    private String description;
+
     @Valid
     @NotEmpty(message = "질문은 최소 1개 이상이어야 합니다.")
     private List<QuestionDto> questions = new ArrayList<>();

--- a/src/main/java/com/command/itdaserver/domain/post/presentation/dto/response/ApplyFormResponse.java
+++ b/src/main/java/com/command/itdaserver/domain/post/presentation/dto/response/ApplyFormResponse.java
@@ -1,0 +1,25 @@
+package com.command.itdaserver.domain.post.presentation.dto.response;
+
+import com.command.itdaserver.domain.post.domain.ApplyForm;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class ApplyFormResponse {
+
+    private Long formId;
+    private String title;
+    private String description;
+    private List<QuestionResponse> questions = new ArrayList<>();
+
+    public ApplyFormResponse(ApplyForm applyForm) {
+        this.formId = applyForm.getId();
+        this.title = applyForm.getTitle();
+        this.description = applyForm.getDescription();
+        this.questions = applyForm.getQuestions().stream()
+                .map(QuestionResponse::new)
+                .toList();
+    }
+}

--- a/src/main/java/com/command/itdaserver/domain/post/presentation/dto/response/PostResponse.java
+++ b/src/main/java/com/command/itdaserver/domain/post/presentation/dto/response/PostResponse.java
@@ -24,7 +24,7 @@ public class PostResponse {
     private long likeCount;
     private boolean isLikedByMe;
     private boolean isBookmarked;
-    private List<QuestionResponse> questions = new ArrayList<>();
+    private boolean hasApplyForm;
     private List<CommentResponse> comments = new ArrayList<>();
 
     public PostResponse(Post post, boolean isLikedByMe, boolean isBookmarked) {
@@ -41,9 +41,7 @@ public class PostResponse {
         this.likeCount = post.getLikeCount();
         this.isLikedByMe = isLikedByMe;
         this.isBookmarked = isBookmarked;
-        this.questions = post.getQuestions().stream()
-                .map(QuestionResponse::new)
-                .toList();
+        this.hasApplyForm = post.hasApplyForm();
         this.comments = post.getComments().stream()
                 .filter(c -> !c.isReply())
                 .map(CommentResponse::new)

--- a/src/main/java/com/command/itdaserver/domain/post/service/CreateApplyFormService.java
+++ b/src/main/java/com/command/itdaserver/domain/post/service/CreateApplyFormService.java
@@ -13,14 +13,11 @@ import com.command.itdaserver.domain.post.exceptions.PostNotFoundException;
 import com.command.itdaserver.domain.post.exceptions.SubjectiveQuestionHasOptionsException;
 import com.command.itdaserver.domain.post.exceptions.UnauthorizedPostAccessException;
 import com.command.itdaserver.domain.post.presentation.dto.request.CreateFormRequest;
-import com.command.itdaserver.domain.post.presentation.dto.response.QuestionResponse;
+import com.command.itdaserver.domain.post.presentation.dto.response.ApplyFormResponse;
 import com.command.itdaserver.global.auth.CustomUserDetails;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -30,9 +27,7 @@ public class CreateApplyFormService {
     private final ApplyFormRepository applyFormRepository;
 
     @Transactional
-    public List<QuestionResponse> execute(Long postId, CreateFormRequest request, CustomUserDetails userDetails) {
-
-        List<QuestionResponse> questions = new ArrayList<>();
+    public ApplyFormResponse execute(Long postId, CreateFormRequest request, CustomUserDetails userDetails) {
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> PostNotFoundException.EXCEPTION);
@@ -74,10 +69,9 @@ public class CreateApplyFormService {
                 }
             }
             applyForm.addQuestion(question);
-            questions.add(new QuestionResponse(question));
         }
 
         applyFormRepository.save(applyForm);
-        return questions;
+        return new ApplyFormResponse(applyForm);
     }
 }

--- a/src/main/java/com/command/itdaserver/domain/post/service/CreateApplyFormService.java
+++ b/src/main/java/com/command/itdaserver/domain/post/service/CreateApplyFormService.java
@@ -1,9 +1,11 @@
 package com.command.itdaserver.domain.post.service;
 
+import com.command.itdaserver.domain.post.domain.ApplyForm;
 import com.command.itdaserver.domain.post.domain.Post;
 import com.command.itdaserver.domain.post.domain.Question;
 import com.command.itdaserver.domain.post.domain.QuestionOption;
 import com.command.itdaserver.domain.post.domain.enums.AnswerType;
+import com.command.itdaserver.domain.post.domain.repository.ApplyFormRepository;
 import com.command.itdaserver.domain.post.domain.repository.PostRepository;
 import com.command.itdaserver.domain.post.exceptions.ApplyFormAlreadyExistsException;
 import com.command.itdaserver.domain.post.exceptions.MissingQuestionOptionException;
@@ -25,11 +27,11 @@ import java.util.List;
 public class CreateApplyFormService {
 
     private final PostRepository postRepository;
+    private final ApplyFormRepository applyFormRepository;
 
     @Transactional
     public List<QuestionResponse> execute(Long postId, CreateFormRequest request, CustomUserDetails userDetails) {
 
-        // 반환을 위해 저장할 Question 리스트
         List<QuestionResponse> questions = new ArrayList<>();
 
         Post post = postRepository.findById(postId)
@@ -41,9 +43,11 @@ public class CreateApplyFormService {
         }
 
         // 이미 지원 폼이 존재하는 경우
-        if (!post.getQuestions().isEmpty()) {
+        if (applyFormRepository.existsByPost(post)) {
             throw ApplyFormAlreadyExistsException.EXCEPTION;
         }
+
+        ApplyForm applyForm = ApplyForm.create(post, request.getTitle(), request.getDescription());
 
         for (var qDto : request.getQuestions()) {
             Question question = Question.builder()
@@ -53,8 +57,8 @@ public class CreateApplyFormService {
                     .multiple(qDto.getMultiple())
                     .required(qDto.getRequired())
                     .build();
-            if (qDto.getAnswerType() == AnswerType.OBJECTIVE) { // 객관식인 경우 옵션 추가
-                if (qDto.getOptions() == null  || qDto.getOptions().isEmpty()) {
+            if (qDto.getAnswerType() == AnswerType.OBJECTIVE) {
+                if (qDto.getOptions() == null || qDto.getOptions().isEmpty()) {
                     throw MissingQuestionOptionException.EXCEPTION;
                 }
                 for (var optDto : qDto.getOptions()) {
@@ -62,16 +66,18 @@ public class CreateApplyFormService {
                             .answerNumber(optDto.getAnswerNumber())
                             .answerContent(optDto.getAnswerContent())
                             .build();
-                    question.addOptions(option); // Cascade 이기 때문에 DB 저장됨
+                    question.addOptions(option);
                 }
-            } else { // 주관식인 경우 옵션이 있으면 예외
+            } else {
                 if (qDto.getOptions() != null && !qDto.getOptions().isEmpty()) {
                     throw SubjectiveQuestionHasOptionsException.EXCEPTION;
                 }
             }
-            post.addQuestion(question); // Cascade 이기 때문에 DB 저장됨
+            applyForm.addQuestion(question);
             questions.add(new QuestionResponse(question));
         }
+
+        applyFormRepository.save(applyForm);
         return questions;
     }
 }

--- a/src/main/java/com/command/itdaserver/domain/post/service/DeletePostService.java
+++ b/src/main/java/com/command/itdaserver/domain/post/service/DeletePostService.java
@@ -1,5 +1,6 @@
 package com.command.itdaserver.domain.post.service;
 
+import com.command.itdaserver.domain.post.domain.ApplyForm;
 import com.command.itdaserver.domain.post.domain.repository.AnswerRepository;
 import com.command.itdaserver.domain.post.domain.repository.PostRepository;
 import com.command.itdaserver.domain.post.exceptions.PostNotFoundException;
@@ -28,7 +29,10 @@ public class DeletePostService {
         }
 
         // Answer가 Question을 참조하므로 먼저 삭제
-        answerRepository.deleteAllByQuestionIn(post.getQuestions());
+        ApplyForm applyForm = post.getApplyForm();
+        if (applyForm != null) {
+            answerRepository.deleteAllByQuestionIn(applyForm.getQuestions());
+        }
 
         postRepository.delete(post);
     }

--- a/src/main/java/com/command/itdaserver/domain/post/service/GetApplyFormService.java
+++ b/src/main/java/com/command/itdaserver/domain/post/service/GetApplyFormService.java
@@ -1,0 +1,31 @@
+package com.command.itdaserver.domain.post.service;
+
+import com.command.itdaserver.domain.post.domain.ApplyForm;
+import com.command.itdaserver.domain.post.domain.Post;
+import com.command.itdaserver.domain.post.domain.repository.ApplyFormRepository;
+import com.command.itdaserver.domain.post.domain.repository.PostRepository;
+import com.command.itdaserver.domain.post.exceptions.ApplyFormNotFoundException;
+import com.command.itdaserver.domain.post.exceptions.PostNotFoundException;
+import com.command.itdaserver.domain.post.presentation.dto.response.ApplyFormResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class GetApplyFormService {
+
+    private final PostRepository postRepository;
+    private final ApplyFormRepository applyFormRepository;
+
+    @Transactional(readOnly = true)
+    public ApplyFormResponse execute(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> PostNotFoundException.EXCEPTION);
+
+        ApplyForm applyForm = applyFormRepository.findByPost(post)
+                .orElseThrow(() -> ApplyFormNotFoundException.EXCEPTION);
+
+        return new ApplyFormResponse(applyForm);
+    }
+}

--- a/src/main/java/com/command/itdaserver/domain/post/service/SubmitAnswerService.java
+++ b/src/main/java/com/command/itdaserver/domain/post/service/SubmitAnswerService.java
@@ -1,6 +1,7 @@
 package com.command.itdaserver.domain.post.service;
 
 import com.command.itdaserver.domain.post.domain.Answer;
+import com.command.itdaserver.domain.post.domain.ApplyForm;
 import com.command.itdaserver.domain.post.domain.Application;
 import com.command.itdaserver.domain.post.domain.Post;
 import com.command.itdaserver.domain.post.domain.Question;
@@ -11,6 +12,7 @@ import com.command.itdaserver.domain.post.domain.repository.ApplicationRepositor
 import com.command.itdaserver.domain.post.domain.repository.PostRepository;
 import com.command.itdaserver.domain.post.domain.repository.QuestionOptionRepository;
 import com.command.itdaserver.domain.post.domain.repository.QuestionRepository;
+import com.command.itdaserver.domain.post.exceptions.ApplyFormNotFoundException;
 import com.command.itdaserver.domain.post.exceptions.DuplicateApplicationException;
 import com.command.itdaserver.domain.post.exceptions.DuplicateOptionSelectException;
 import com.command.itdaserver.domain.post.exceptions.InvalidQuestionOptionException;
@@ -64,12 +66,18 @@ public class SubmitAnswerService {
             throw DuplicateApplicationException.EXCEPTION;
         }
 
+        // ApplyForm 존재 확인
+        ApplyForm applyForm = post.getApplyForm();
+        if (applyForm == null) {
+            throw ApplyFormNotFoundException.EXCEPTION;
+        }
+
         // 필수 질문이 answers 리스트에 포함됐는지 사전 검증
         Set<Long> submittedQuestionIds = request.getAnswers().stream()
                 .map(SubmitAnswerRequest.AnswerDto::getQuestionId)
                 .collect(Collectors.toSet());
 
-        boolean hasRequiredMissing = post.getQuestions().stream()
+        boolean hasRequiredMissing = applyForm.getQuestions().stream()
                 .filter(Question::isRequired)
                 .anyMatch(q -> !submittedQuestionIds.contains(q.getId()));
 
@@ -84,8 +92,8 @@ public class SubmitAnswerService {
 
         for (SubmitAnswerRequest.AnswerDto dto : request.getAnswers()) {
 
-            // questionId가 해당 post 소속인지 검증
-            Question question = questionRepository.findByIdAndPost(dto.getQuestionId(), post)
+            // questionId가 해당 applyForm 소속인지 검증
+            Question question = questionRepository.findByIdAndApplyForm(dto.getQuestionId(), applyForm)
                     .orElseThrow(() -> QuestionNotFoundException.EXCEPTION);
 
             if (question.getAnswerType() == AnswerType.OBJECTIVE) {

--- a/src/main/java/com/command/itdaserver/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/command/itdaserver/global/error/exception/ErrorCode.java
@@ -42,6 +42,9 @@ public enum ErrorCode {
     DUPLICATE_OPTION_SELECT(400, "중복된 선택지가 포함되어 있습니다."),
     SUBJECTIVE_QUESTION_HAS_OPTIONS(400, "주관식 질문에는 보기를 추가할 수 없습니다."),
 
+    // apply form
+    APPLY_FORM_NOT_FOUND(404, "해당 신청서가 존재하지 않습니다."),
+
     // application
     APPLICATION_NOT_FOUND(404, "해당 지원서가 존재하지 않습니다."),
     DUPLICATE_APPLICATION(409, "이미 해당 게시글에 지원하셨습니다."),


### PR DESCRIPTION
## 💡 배경 및 개요
>기존 "신청 폼" 을 뜻하던 엔티티인 "Question" 은 DB 기준 컬럼별으로 저장되고 있었음.
> -> 즉, 한 Post 에 여러 Question 이 존재했었고, 이를 하나로 확립하기도 힘들었으며, 이를 제외한 다양한 성능적인 많은 문제가 있었음.
> 기존 "Question" 들을 하나로 확립하는 "Form" 엔티티를 만들어 하나로 확립할 수 있도록 함.


Resolves: #{[30](https://github.com/Team-Command/itda-server/issues/30)}

## 📃 작업내용

> 커밋 메시지 참고

## 🔀 변경사항

> 커밋 메시지 참고

## 🙋‍♂️ 리뷰노트

> 전 구조 에서 현 구조로 변경된 것을 중점으로, DB 구조를 중심적으로 봐주세요. 
- 전 구조
    - 1 (Post) : N (Question)
 - 현 구조
     - 1 (Post) : 1 (Form) : N(Question)

## ✅ PR 체크리스트
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
