### PR TITLE
fix: 게시글 삭제 시 Application FK 미처리로 인한 500 에러 수정

### DIFF
--- a/src/main/java/com/command/itdaserver/domain/post/domain/repository/ApplicationRepository.java
+++ b/src/main/java/com/command/itdaserver/domain/post/domain/repository/ApplicationRepository.java
@@ -16,4 +16,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     Optional<Application> findByIdAndPost(Long id, Post post);
 
+    void deleteAllByPost(Post post);
+
 }

--- a/src/main/java/com/command/itdaserver/domain/post/domain/repository/ApplicationRepository.java
+++ b/src/main/java/com/command/itdaserver/domain/post/domain/repository/ApplicationRepository.java
@@ -16,6 +16,4 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     Optional<Application> findByIdAndPost(Long id, Post post);
 
-    void deleteAllByPost(Post post);
-
 }

--- a/src/main/java/com/command/itdaserver/domain/post/service/DeletePostService.java
+++ b/src/main/java/com/command/itdaserver/domain/post/service/DeletePostService.java
@@ -36,8 +36,8 @@ public class DeletePostService {
             answerRepository.deleteAllByQuestionIn(applyForm.getQuestions());
         }
 
-        // Application이 post_id FK를 가지므로 Post 삭제 전에 먼저 삭제
-        applicationRepository.deleteAllByPost(post);
+        // Application이 post_id FK를 가지므로 Post 삭제 전에 먼저 삭제 (cascade 적용을 위해 영속성 컨텍스트 통해 삭제)
+        applicationRepository.deleteAll(applicationRepository.findAllByPost(post));
 
         postRepository.delete(post);
     }

--- a/src/main/java/com/command/itdaserver/domain/post/service/DeletePostService.java
+++ b/src/main/java/com/command/itdaserver/domain/post/service/DeletePostService.java
@@ -2,6 +2,7 @@ package com.command.itdaserver.domain.post.service;
 
 import com.command.itdaserver.domain.post.domain.ApplyForm;
 import com.command.itdaserver.domain.post.domain.repository.AnswerRepository;
+import com.command.itdaserver.domain.post.domain.repository.ApplicationRepository;
 import com.command.itdaserver.domain.post.domain.repository.PostRepository;
 import com.command.itdaserver.domain.post.exceptions.PostNotFoundException;
 import com.command.itdaserver.domain.post.exceptions.UnauthorizedPostAccessException;
@@ -16,6 +17,7 @@ public class DeletePostService {
 
     private final PostRepository postRepository;
     private final AnswerRepository answerRepository;
+    private final ApplicationRepository applicationRepository;
 
     @Transactional
     public void execute(Long postId, CustomUserDetails userDetails) {
@@ -33,6 +35,9 @@ public class DeletePostService {
         if (applyForm != null) {
             answerRepository.deleteAllByQuestionIn(applyForm.getQuestions());
         }
+
+        // Application이 post_id FK를 가지므로 Post 삭제 전에 먼저 삭제
+        applicationRepository.deleteAllByPost(post);
 
         postRepository.delete(post);
     }


### PR DESCRIPTION
## 💡 배경 및 개요
> Post 삭제 시, Application 과 FK 구조로 인한 삭제 불가 및 에러 발생, 해결을 위함

## 📃 작업내용

> ApplicationRepository에 deleteAllByPost(Post post) 추가 후, DeletePostService에서 Post 삭제 전에 Application 먼저 삭제하도록 변경

## 🔀 변경사항

> Post 와 연관된 삭제형식 개선 및 변경

## 🙋‍♂️ 리뷰노트

> None

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
